### PR TITLE
refactor(contracts): use existing `trustedHeader`

### DIFF
--- a/contracts/src/interfaces/ITendermintX.sol
+++ b/contracts/src/interfaces/ITendermintX.sol
@@ -23,6 +23,9 @@ interface ITendermintX {
         uint64 indexed targetBlock
     );
 
+    /// @notice Trusted header not found.
+    error TrustedHeaderNotFound();
+
     /// @notice Latest header not found.
     error LatestHeaderNotFound();
 


### PR DESCRIPTION
- Refactor `skip` and `step` to read `trustedHeader` from contract state.