### PR TITLE
refactor: rm `/header` requests

### DIFF
--- a/bin/tendermintx.rs
+++ b/bin/tendermintx.rs
@@ -156,8 +156,8 @@ impl TendermintXOperator {
             let current_block = self.contract.latest_block().await.unwrap();
 
             // Get the head of the chain.
-            let latest_header = self.data_fetcher.get_latest_header().await;
-            let latest_block = latest_header.height.value();
+            let latest_signed_header = self.data_fetcher.get_latest_signed_header().await;
+            let latest_block = latest_signed_header.header.height.value();
 
             // Subtract 2 blocks to account for the time it takes for a block to be processed by
             // consensus.

--- a/circuits/builder/validator.rs
+++ b/circuits/builder/validator.rs
@@ -264,17 +264,22 @@ pub(crate) mod tests {
         let input_data_fetcher = InputDataFetcher::default();
 
         let rt = Runtime::new().expect("failed to create tokio runtime");
-        let header =
-            rt.block_on(async { input_data_fetcher.get_header_from_number(10000u64).await });
+        let signed_header = rt.block_on(async {
+            input_data_fetcher
+                .get_signed_header_from_number(10000u64)
+                .await
+        });
 
-        let (root, proofs) = generate_proofs_from_header(&header);
+        let (root, proofs) = generate_proofs_from_header(&signed_header.header);
 
         // Can test with leaf_index 2, 4, 6, 7 or 8 (height, last_block_id_hash, data_hash, validators_hash, next_validators_hash)
         // TODO: Add tests for all leaf indices that are used.
         let leaf_index = 4;
 
         // Note: Must convert to protobuf encoding (get_proofs_from_header is a good reference)
-        let leaf = Protobuf::<RawBlockId>::encode_vec(header.last_block_id.unwrap_or_default());
+        let leaf = Protobuf::<RawBlockId>::encode_vec(
+            signed_header.header.last_block_id.unwrap_or_default(),
+        );
 
         let path_indices = get_path_indices(leaf_index as u64, proofs[0].total);
 


### PR DESCRIPTION
Not all Cosmos chains have a `/header` endpoint, so use `/commit` and `SignedHeader` instead.