### PR TITLE
fix: verify height, cleanup

### DIFF
--- a/circuits/builder/shared.rs
+++ b/circuits/builder/shared.rs
@@ -6,9 +6,15 @@ use plonky2x::prelude::{
     CircuitVariable, Field, PlonkParameters, Variable,
 };
 
-use crate::consts::{HEADER_PROOF_DEPTH, PROTOBUF_VARINT_SIZE_BYTES, VARINT_BYTES_LENGTH_MAX};
+use crate::consts::{
+    BLOCK_HEIGHT_INDEX, HEADER_PROOF_DEPTH, PROTOBUF_VARINT_SIZE_BYTES, VARINT_BYTES_LENGTH_MAX,
+};
 
 pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
+    /// Get the path to a leaf in the Tendermint header.
+    fn get_path_to_leaf(&mut self, index: usize)
+        -> ArrayVariable<BoolVariable, HEADER_PROOF_DEPTH>;
+
     /// Serializes an int64 as a protobuf varint.
     fn marshal_int64_varint(
         &mut self,
@@ -33,6 +39,29 @@ pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
 }
 
 impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBuilder<L, D> {
+    /// Get the path to a leaf in the Tendermint header.
+    fn get_path_to_leaf(
+        &mut self,
+        index: usize,
+    ) -> ArrayVariable<BoolVariable, HEADER_PROOF_DEPTH> {
+        let false_t = self._false();
+        let true_t = self._true();
+
+        // The path to the leaf in a Tendermint header.
+        let mut path = Vec::new();
+        let mut curr_idx = index;
+        for _ in 0..HEADER_PROOF_DEPTH {
+            if curr_idx % 2 == 0 {
+                path.push(false_t);
+            } else {
+                path.push(true_t);
+            }
+            curr_idx /= 2;
+        }
+
+        ArrayVariable::<BoolVariable, HEADER_PROOF_DEPTH>::new(path)
+    }
+
     fn marshal_int64_varint(
         &mut self,
         value: &U64Variable,
@@ -143,9 +172,7 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBu
         height: &U64Variable,
         encoded_height_byte_length: U32Variable,
     ) {
-        let false_t = self._false();
-        let true_t = self._true();
-        let block_height_path = vec![false_t, true_t, false_t, false_t];
+        let block_height_path = self.get_path_to_leaf(BLOCK_HEIGHT_INDEX);
 
         // Marshal the block height into bytes, then encode it as a leaf.
         let encoded_height = self.marshal_int64_varint(height);
@@ -169,7 +196,7 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBu
         // Verify the computed block height against the header.
         let computed_header = self.get_root_from_merkle_proof_hashed_leaf::<HEADER_PROOF_DEPTH>(
             proof,
-            &block_height_path.into(),
+            &block_height_path,
             leaf_hash,
         );
 

--- a/circuits/builder/shared.rs
+++ b/circuits/builder/shared.rs
@@ -21,8 +21,8 @@ pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
         num: &U64Variable,
     ) -> [ByteVariable; VARINT_BYTES_LENGTH_MAX];
 
-    /// Encodes the marshalled height into a BytesVariable<11> that can be hashed according to the Tendermint spec.
-    /// Prepends a 0x00 byte for the leaf prefix and a 0x08 byte for the marshalled varint encoding.
+    /// Encodes the marshalled height into a BytesVariable<11> that can be hashed according to the
+    /// Tendermint spec. Prepends 0x00 byte as leaf prefix and 0x08 byte for varint encoding.
     fn leaf_encode_marshalled_varint(
         &mut self,
         marshalled_varint: &BytesVariable<9>,

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -18,10 +18,6 @@ use crate::consts::{
 use crate::variables::*;
 
 pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
-    /// Get the path to a leaf in the Tendermint header.
-    fn get_path_to_leaf(&mut self, index: usize)
-        -> ArrayVariable<BoolVariable, HEADER_PROOF_DEPTH>;
-
     /// Extract the header hash from the signed message from a validator. The location of the
     /// header hash in the signed message depends on whether the round is 0 for the message.
     fn verify_hash_in_message(
@@ -152,28 +148,6 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
 }
 
 impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBuilder<L, D> {
-    fn get_path_to_leaf(
-        &mut self,
-        index: usize,
-    ) -> ArrayVariable<BoolVariable, HEADER_PROOF_DEPTH> {
-        let false_t = self._false();
-        let true_t = self._true();
-
-        // The path to the leaf in a Tendermint header.
-        let mut path = Vec::new();
-        let mut curr_idx = index;
-        for _ in 0..HEADER_PROOF_DEPTH {
-            if curr_idx % 2 == 0 {
-                path.push(false_t);
-            } else {
-                path.push(true_t);
-            }
-            curr_idx /= 2;
-        }
-
-        ArrayVariable::<BoolVariable, HEADER_PROOF_DEPTH>::new(path)
-    }
-
     fn verify_hash_in_message(
         &mut self,
         message: &ValidatorMessageVariable,

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -55,9 +55,9 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
         header: &TendermintHashVariable,
     );
 
-    /// Verify a Tendermint consensus block. Specifically, verify that 2/3 of the validators in
-    /// header's validators set signed on a message that includes the header hash, and that the
-    /// chain ID in the header matches the expected chain ID.
+    /// Verify a Tendermint consensus block. Specifically, verify that 2/3 of the validator set
+    /// specified in the header signed on a Precommit message that includes the header hash, and
+    /// that the chain ID in the header matches the expected chain ID.
     fn verify_header<const VALIDATOR_SET_SIZE_MAX: usize, const CHAIN_ID_SIZE_BYTES: usize>(
         &mut self,
         expected_chain_id_bytes: &[u8],
@@ -133,6 +133,7 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
     fn verify_skip<const VALIDATOR_SET_SIZE_MAX: usize, const CHAIN_ID_SIZE_BYTES: usize>(
         &mut self,
         expected_chain_id_bytes: &[u8],
+        target_block: &U64Variable,
         validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
         nb_enabled_validators: Variable,
         header: &TendermintHashVariable,
@@ -577,6 +578,7 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
     fn verify_skip<const VALIDATOR_SET_SIZE_MAX: usize, const CHAIN_ID_SIZE_BYTES: usize>(
         &mut self,
         expected_chain_id_bytes: &[u8],
+        target_block: &U64Variable,
         validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
         nb_enabled_validators: Variable,
         header: &TendermintHashVariable,
@@ -621,7 +623,8 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
             &header_height_proof.proof,
             &header_height_proof.height,
             header_height_proof.enc_height_byte_length,
-        )
+        );
+        self.assert_is_equal(*target_block, header_height_proof.height);
     }
 }
 

--- a/circuits/consts.rs
+++ b/circuits/consts.rs
@@ -14,18 +14,18 @@ pub const PROTOBUF_HASH_SIZE_BYTES: usize = HASH_SIZE + 2;
 /// The number of bytes in a protobuf-encoded tendermint block ID.
 pub const PROTOBUF_BLOCK_ID_SIZE_BYTES: usize = 72;
 
-// Depth of the proofs against the header.
+/// Depth of the proofs against the header.
 pub const HEADER_PROOF_DEPTH: usize = 4;
 
 /// The maximum length of a protobuf-encoded Tendermint validator in bytes.
 pub const VALIDATOR_BYTE_LENGTH_MAX: usize = 46;
 
-// The maximum number of bytes in a protobuf-encoded varint.
-// https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#tendermint-networks
+/// The maximum number of bytes in a protobuf-encoded varint.
+/// https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#tendermint-networks
 pub const VARINT_BYTES_LENGTH_MAX: usize = 9;
 pub const PROTOBUF_VARINT_SIZE_BYTES: usize = VARINT_BYTES_LENGTH_MAX + 1;
 
-// The maximum number of bytes in a validator message (CanonicalVote toSignBytes).
+/// The maximum number of bytes in a validator message (CanonicalVote toSignBytes).
 pub const VALIDATOR_MESSAGE_BYTES_LENGTH_MAX: usize = 124;
 
 // Header indices for the Merkle tree.

--- a/circuits/skip.rs
+++ b/circuits/skip.rs
@@ -60,6 +60,7 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintSkipCircuit<L, D> for Circ
 
         self.verify_skip::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
+            &target_block,
             &target_block_validators,
             nb_validators,
             &target_header,


### PR DESCRIPTION
Fix: Verify the `targetBlock` matches the `height` of the header in `skip`
- Note: We don't need to do this for `step`, because we've already proven they're linked.