### PR TITLE
feat(audit): verify skip distance

### DIFF
--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -120,6 +120,16 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
         round_present: &BoolVariable,
     );
 
+    /// Verify trusted_block + SKIP_MAX > target_block > trusted_block + 1. The target block must be
+    /// greater than & non-adjacent to the trusted_block, and must be less than SKIP_MAX blocks
+    /// away from the trusted_block.
+    fn verify_skip_distance(
+        &mut self,
+        skip_max: usize,
+        trusted_block: &U64Variable,
+        target_block: &U64Variable,
+    );
+
     /// Verify a Tendermint block that is non-sequential with the trusted block. At least 1/3 of the
     /// stake on the new block must be from validators on the trusted block to skip intermediate
     /// verification. Additionally, the new block must have 2/3 of the validators signed on it.
@@ -129,6 +139,8 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
     fn verify_skip<const VALIDATOR_SET_SIZE_MAX: usize, const CHAIN_ID_SIZE_BYTES: usize>(
         &mut self,
         expected_chain_id_bytes: &[u8],
+        skip_max: usize,
+        trusted_block: &U64Variable,
         target_block: &U64Variable,
         validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
         nb_enabled_validators: Variable,
@@ -549,9 +561,28 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         );
     }
 
+    fn verify_skip_distance(
+        &mut self,
+        skip_max: usize,
+        trusted_block: &U64Variable,
+        target_block: &U64Variable,
+    ) {
+        let one = self.one();
+        let trusted_block_plus_one = self.add(*trusted_block, one);
+        // Verify target block > trusted block.
+        self.gt(*target_block, trusted_block_plus_one);
+
+        let skip_max_var = self.constant::<U64Variable>(skip_max as u64);
+        let max_block = self.add(*trusted_block, skip_max_var);
+        // Verify target block <= trusted block + skip_max.
+        self.lte(*target_block, max_block);
+    }
+
     fn verify_skip<const VALIDATOR_SET_SIZE_MAX: usize, const CHAIN_ID_SIZE_BYTES: usize>(
         &mut self,
         expected_chain_id_bytes: &[u8],
+        skip_max: usize,
+        trusted_block: &U64Variable,
         target_block: &U64Variable,
         validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
         nb_enabled_validators: Variable,
@@ -568,6 +599,10 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         >,
         trusted_nb_enabled_validators: Variable,
     ) {
+        // Verify the target block is non-sequential with the trusted block and within maximum
+        // skip distance.
+        self.verify_skip_distance(skip_max, trusted_block, target_block);
+
         // Verify the validators from the target block marked present_on_trusted_header
         // are present on the trusted header, and comprise at least 1/3 of the total voting power
         // on the target block.

--- a/circuits/config.rs
+++ b/circuits/config.rs
@@ -4,7 +4,12 @@ pub trait TendermintConfig<const CHAIN_ID_SIZE_BYTES: usize>:
     Debug + Clone + PartialEq + Sync + Send + 'static
 {
     const CHAIN_ID_BYTES: &'static [u8];
+    const SKIP_MAX: usize;
 }
+
+/// @notice The maximum number of blocks that can be skipped. Below, this is set to 2 weeks, which
+/// is roughly 100800 blocks if the block time is 12 seconds.
+pub const SKIP_MAX: usize = 100800;
 
 /// Celestia's chain config.
 pub const CELESTIA_CHAIN_ID_BYTES: &[u8] = b"celestia";
@@ -13,6 +18,7 @@ pub const CELESTIA_CHAIN_ID_SIZE_BYTES: usize = CELESTIA_CHAIN_ID_BYTES.len();
 pub struct CelestiaConfig;
 impl TendermintConfig<CELESTIA_CHAIN_ID_SIZE_BYTES> for CelestiaConfig {
     const CHAIN_ID_BYTES: &'static [u8] = CELESTIA_CHAIN_ID_BYTES;
+    const SKIP_MAX: usize = SKIP_MAX;
 }
 
 /// Mocha-4's chain config.
@@ -22,4 +28,5 @@ pub const MOCHA_4_CHAIN_ID_SIZE_BYTES: usize = MOCHA_4_CHAIN_ID_BYTES.len();
 pub struct Mocha4Config;
 impl TendermintConfig<MOCHA_4_CHAIN_ID_SIZE_BYTES> for Mocha4Config {
     const CHAIN_ID_BYTES: &'static [u8] = MOCHA_4_CHAIN_ID_BYTES;
+    const SKIP_MAX: usize = SKIP_MAX;
 }

--- a/circuits/skip.rs
+++ b/circuits/skip.rs
@@ -60,16 +60,10 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintSkipCircuit<L, D> for Circ
             .read::<ArrayVariable<ValidatorHashFieldVariable, MAX_VALIDATOR_SET_SIZE>>(self);
         let trusted_nb_validators = output_stream.read::<Variable>(self);
 
-        // Verify target block > trusted block.
-        self.gt(target_block, trusted_block);
-
-        let skip_max_var = self.constant::<U64Variable>(skip_max as u64);
-        let max_block = self.add(trusted_block, skip_max_var);
-        // Verify target block <= trusted block + skip_max.
-        self.lte(target_block, max_block);
-
         self.verify_skip::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
+            skip_max,
+            &trusted_block,
             &target_block,
             &target_block_validators,
             nb_validators,

--- a/circuits/step.rs
+++ b/circuits/step.rs
@@ -154,15 +154,7 @@ mod tests {
     use plonky2x::prelude::{DefaultBuilder, GateRegistry, HintRegistry};
 
     use super::*;
-    use crate::config::TendermintConfig;
-
-    const CHAIN_ID_BYTES: &[u8] = b"mocha-4";
-    const CHAIN_ID_SIZE_BYTES: usize = CHAIN_ID_BYTES.len();
-    #[derive(Debug, Clone, PartialEq)]
-    pub struct Mocha4Config;
-    impl TendermintConfig<CHAIN_ID_SIZE_BYTES> for Mocha4Config {
-        const CHAIN_ID_BYTES: &'static [u8] = CHAIN_ID_BYTES;
-    }
+    use crate::config::{Mocha4Config, MOCHA_4_CHAIN_ID_SIZE_BYTES};
 
     #[test]
     #[cfg_attr(feature = "ci", ignore)]
@@ -174,7 +166,7 @@ mod tests {
         let mut builder = DefaultBuilder::new();
 
         log::debug!("Defining circuit");
-        StepCircuit::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
+        StepCircuit::<MAX_VALIDATOR_SET_SIZE, MOCHA_4_CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
             &mut builder,
         );
         let circuit = builder.build();
@@ -182,10 +174,10 @@ mod tests {
 
         let mut hint_registry = HintRegistry::new();
         let mut gate_registry = GateRegistry::new();
-        StepCircuit::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES, Mocha4Config>::register_generators(
+        StepCircuit::<MAX_VALIDATOR_SET_SIZE, MOCHA_4_CHAIN_ID_SIZE_BYTES, Mocha4Config>::register_generators(
             &mut hint_registry,
         );
-        StepCircuit::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES, Mocha4Config>::register_gates(
+        StepCircuit::<MAX_VALIDATOR_SET_SIZE, MOCHA_4_CHAIN_ID_SIZE_BYTES, Mocha4Config>::register_gates(
             &mut gate_registry,
         );
 
@@ -209,7 +201,7 @@ mod tests {
         let mut builder = DefaultBuilder::new();
 
         log::debug!("Defining circuit");
-        StepCircuit::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
+        StepCircuit::<MAX_VALIDATOR_SET_SIZE, MOCHA_4_CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
             &mut builder,
         );
 
@@ -233,7 +225,7 @@ mod tests {
         let mut builder = DefaultBuilder::new();
 
         log::debug!("Defining circuit");
-        StepCircuit::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
+        StepCircuit::<MAX_VALIDATOR_SET_SIZE, MOCHA_4_CHAIN_ID_SIZE_BYTES, Mocha4Config>::define(
             &mut builder,
         );
 


### PR DESCRIPTION
https://github.com/succinctlabs/tendermintx/issues/38

Verify `targetBlock` > `trustedBlock` + 1 in `skip` (`targetBlock` must be greater and non-adjacent).

We also verify `targetBlock` as the height of `targetHeader`
- We don't need to check this in `step` as the validators could be slashed for equivocating two blocks that have `trustedHeaderHash` as the `lastBlockId`.