### PR TITLE
fix(audit): `is_voting_power_greater_than_threshold`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,7 +3030,7 @@ source = "git+https://github.com/mir-protocol/plonky2.git?rev=2d36559d#2d36559da
 [[package]]
 name = "plonky2x"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/succinctx.git#19a16bfd14b3367c6c022ba6477457baca9d84b3"
+source = "git+https://github.com/succinctlabs/succinctx.git?branch=ratan/lt-fix#d9a010f8ab2b091ea71bba58b52d53ed2fb74b6d"
 dependencies = [
  "anyhow",
  "array-macro",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "plonky2x-derive"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/succinctx.git#19a16bfd14b3367c6c022ba6477457baca9d84b3"
+source = "git+https://github.com/succinctlabs/succinctx.git?branch=ratan/lt-fix#d9a010f8ab2b091ea71bba58b52d53ed2fb74b6d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ ethers = "2.0.9"
 itertools = "0.11.0"
 log = "0.4.19"
 num = "0.4.1"
-plonky2x = { git = "https://github.com/succinctlabs/succinctx.git" }
+plonky2x = { git = "https://github.com/succinctlabs/succinctx.git", branch = "ratan/lt-fix" }
 succinct-client = { git = "https://github.com/succinctlabs/succinctx.git" }
 rand = "0.8.5"
 reqwest = "0.11.18"

--- a/circuits/builder/voting.rs
+++ b/circuits/builder/voting.rs
@@ -73,13 +73,15 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVoting for CircuitBuilder<
         let scaled_accumulated = self.mul(accumulated_voting_power, *threshold_denominator);
         let scaled_threshold = self.mul(*total_voting_power, *threshold_numerator);
 
-        // Return accumulated_voting_power >= total_vp * (threshold_numerator / threshold_denominator).
-        self.gte(scaled_accumulated, scaled_threshold)
+        // Return accumulated_voting_power > total_vp * (threshold_numerator / threshold_denominator).
+        self.gt(scaled_accumulated, scaled_threshold)
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::env;
+
     use plonky2x::prelude::DefaultBuilder;
 
     use super::*;
@@ -88,6 +90,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_accumulate_voting_power() {
+        env::set_var("RUST_LOG", "info");
         env_logger::try_init().unwrap_or_default();
 
         let test_cases = [
@@ -102,7 +105,7 @@ pub(crate) mod tests {
             (
                 vec![4294967296000i64, 4294967296000i64, 4294967296000i64, 0i64],
                 [1, 1, 0, 0],
-                true,
+                false,
             ),
             (
                 vec![4294967296000i64, 4294967296000i64, 4294967296000i64, 0i64],


### PR DESCRIPTION
TODO: SWITCH BACK TO `main` ON `succinctx` once merged.

When checking if validators from the trusted block comprise at least 1/3 of the total voting power in the untrusted block [greater and equal](https://github.com/succinctlabs/tendermintx/blob/477c70453f38b44568b4f7a0be81c28ef27b4271/circuits/builder/voting.rs#L76-L77) is used whereas in the golang implementation [greater is used](https://github.com/cometbft/cometbft/blob/cf8af38391a029ef586f2e27f16082b5a663c50b/types/validation.go#L391-L399). 

Switch `is_voting_power_greater_than_threshold` to use `gt`.