### PR TITLE
refactor(audit): disambiguate naming

### DIFF
--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -130,13 +130,13 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
         &mut self,
         expected_chain_id_bytes: &[u8],
         target_block: &U64Variable,
-        validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
-        nb_enabled_validators: Variable,
-        header: &TendermintHashVariable,
-        chain_id_proof: &ChainIdProofVariable,
-        header_height_proof: &HeightProofVariable,
-        validator_hash_proof: &HashInclusionProofVariable,
-        round_present: &BoolVariable,
+        target_validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
+        target_header_nb_enabled_validators: Variable,
+        target_header: &TendermintHashVariable,
+        target_header_chain_id_proof: &ChainIdProofVariable,
+        target_header_height_proof: &HeightProofVariable,
+        target_header_validator_hash_proof: &HashInclusionProofVariable,
+        target_header_round_present: &BoolVariable,
         trusted_header: TendermintHashVariable,
         trusted_validator_hash_proof: &HashInclusionProofVariable,
         trusted_validator_hash_fields: &ArrayVariable<
@@ -553,13 +553,13 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         &mut self,
         expected_chain_id_bytes: &[u8],
         target_block: &U64Variable,
-        validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
-        nb_enabled_validators: Variable,
-        header: &TendermintHashVariable,
-        chain_id_proof: &ChainIdProofVariable,
-        header_height_proof: &HeightProofVariable,
-        validator_hash_proof: &HashInclusionProofVariable,
-        round_present: &BoolVariable,
+        target_validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
+        target_header_nb_enabled_validators: Variable,
+        target_header: &TendermintHashVariable,
+        target_header_chain_id_proof: &ChainIdProofVariable,
+        target_header_height_proof: &HeightProofVariable,
+        target_header_validator_hash_proof: &HashInclusionProofVariable,
+        target_header_round_present: &BoolVariable,
         trusted_header: TendermintHashVariable,
         trusted_validator_hash_proof: &HashInclusionProofVariable,
         trusted_validator_hash_fields: &ArrayVariable<
@@ -572,8 +572,8 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         // are present on the trusted header, and comprise at least 1/3 of the total voting power
         // on the target block.
         self.verify_trusted_validators(
-            validators,
-            nb_enabled_validators,
+            target_validators,
+            target_header_nb_enabled_validators,
             trusted_header,
             trusted_validator_hash_proof,
             trusted_validator_hash_fields,
@@ -583,22 +583,22 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         // Verify the target Tendermint consensus block.
         self.verify_header::<VALIDATOR_SET_SIZE_MAX, CHAIN_ID_SIZE_BYTES>(
             expected_chain_id_bytes,
-            validators,
-            nb_enabled_validators,
-            header,
-            chain_id_proof,
-            validator_hash_proof,
-            round_present,
+            target_validators,
+            target_header_nb_enabled_validators,
+            target_header,
+            target_header_chain_id_proof,
+            target_header_validator_hash_proof,
+            target_header_round_present,
         );
 
         // Verify the target block's height is correct.
         self.verify_block_height(
-            *header,
-            &header_height_proof.proof,
-            &header_height_proof.height,
-            header_height_proof.enc_height_byte_length,
+            *target_header,
+            &target_header_height_proof.proof,
+            &target_header_height_proof.height,
+            target_header_height_proof.enc_height_byte_length,
         );
-        self.assert_is_equal(*target_block, header_height_proof.height);
+        self.assert_is_equal(*target_block, target_header_height_proof.height);
     }
 }
 


### PR DESCRIPTION
Update naming convention for `verify_skip` to specify which fields come from the `target_header`.