### PR TITLE
refactor: `verify_skip`, `verify_step`, `verify_block_height`

### DIFF
--- a/circuits/builder/shared.rs
+++ b/circuits/builder/shared.rs
@@ -7,6 +7,7 @@ use plonky2x::prelude::{
 };
 
 use crate::consts::{BLOCK_HEIGHT_INDEX, HEADER_PROOF_DEPTH, VARINT_BYTES_LENGTH_MAX};
+use crate::variables::HeightProofVariable;
 
 pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
     /// Get the path to a leaf in the Tendermint header.
@@ -30,9 +31,8 @@ pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
     fn verify_block_height(
         &mut self,
         header: Bytes32Variable,
-        proof: &ArrayVariable<Bytes32Variable, HEADER_PROOF_DEPTH>,
-        height: &U64Variable,
-        encoded_height_byte_length: U32Variable,
+        height_proof: HeightProofVariable,
+        expected_height: U64Variable,
     );
 
     /// Get result of AND operation for BoolVariable array.
@@ -169,14 +169,13 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBu
     fn verify_block_height(
         &mut self,
         header: Bytes32Variable,
-        proof: &ArrayVariable<Bytes32Variable, HEADER_PROOF_DEPTH>,
-        height: &U64Variable,
-        encoded_height_byte_length: U32Variable,
+        height_proof: HeightProofVariable,
+        expected_height: U64Variable,
     ) {
         let block_height_path = self.get_path_to_leaf(BLOCK_HEIGHT_INDEX);
 
         // Marshal the block height into bytes, then encode it as a leaf.
-        let encoded_height = self.marshal_int64_varint(height);
+        let encoded_height = self.marshal_int64_varint(&height_proof.height);
         let encoded_height = self.leaf_encode_marshalled_varint(&BytesVariable(encoded_height));
 
         // Extend encoded_height to 64 bytes. Variable SHA256 requires the input length in bytes to
@@ -188,7 +187,7 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBu
 
         // Add 1 to the encoded height byte length to account for the 0x00 byte.
         let one_u32 = self.constant::<U32Variable>(1);
-        let encoded_height_byte_length = self.add(encoded_height_byte_length, one_u32);
+        let encoded_height_byte_length = self.add(height_proof.enc_height_byte_length, one_u32);
 
         // Hash the encoded height.
         let leaf_hash =
@@ -196,12 +195,15 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintHeader<L, D> for CircuitBu
 
         // Verify the computed block height against the header.
         let computed_header = self.get_root_from_merkle_proof_hashed_leaf::<HEADER_PROOF_DEPTH>(
-            proof,
+            &height_proof.proof,
             &block_height_path,
             leaf_hash,
         );
 
         self.assert_is_equal(computed_header, header);
+
+        // Verify the block height against the expected height.
+        self.assert_is_equal(height_proof.height, expected_height);
     }
     fn combine_with_and(&mut self, arr: &[BoolVariable]) -> BoolVariable {
         let mut res = self._true();

--- a/circuits/builder/validator.rs
+++ b/circuits/builder/validator.rs
@@ -19,7 +19,15 @@ pub trait TendermintValidator<L: PlonkParameters<D>, const D: usize> {
     /// Verify that the round is non-negative.
     fn verify_non_negative_round(&mut self, le_encoded_round: ArrayVariable<ByteVariable, 8>);
 
-    /// Verify each validator's signature contains the correct data.
+    /// The protobuf encoding of the signed message of the validator follows the spec here:
+    /// https://github.com/cometbft/cometbft/blob/1f430f51f0e390cd7c789ba9b1e9b35846e34642/api/cometbft/types/v1/canonical.pb.go#L233-L242
+    /// If the validator has signed, verify: (a)
+    /// - marked as enabled (b)
+    /// - message includes the header hash (c)
+    /// - MsgType is a Precommit message (d)
+    /// - height of the target_header matches the height in the message (e)
+    /// - if round is non-zero, specified round matches message (all validators have same round) (f)
+    /// Verify a == a * b * c * d * e * f
     fn verify_validator_signature_data(
         &mut self,
         header: &TendermintHashVariable,
@@ -85,17 +93,6 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintValidator<L, D> for Circui
         signed: &BoolVariable,
         round: &U64Variable,
     ) {
-        // The protobuf encoding of the signed message of the validator follows the spec here:
-        // https://github.com/cometbft/cometbft/blob/1f430f51f0e390cd7c789ba9b1e9b35846e34642/api/cometbft/types/v1/canonical.pb.go#L233-L242
-
-        // If signed, (a)
-        // - enabled (b)
-        // - message includes the header hash (c)
-        // - MsgType is a Precommit message (d)
-        // - height of the target_header matches the height in the message (e)
-        // - if round is non-zero, specified round matches message (all validators have same round) (f)
-        // Verify a == a * b * c * d * e * f
-
         // Verify every signed validator's message includes the header hash.
         let hash_in_message = self.verify_hash_in_message(message, *header, *round);
 

--- a/circuits/builder/validator.rs
+++ b/circuits/builder/validator.rs
@@ -19,15 +19,7 @@ pub trait TendermintValidator<L: PlonkParameters<D>, const D: usize> {
     /// Verify that the round is non-negative.
     fn verify_non_negative_round(&mut self, le_encoded_round: ArrayVariable<ByteVariable, 8>);
 
-    /// The protobuf encoding of the signed message of the validator follows the spec here:
-    /// https://github.com/cometbft/cometbft/blob/1f430f51f0e390cd7c789ba9b1e9b35846e34642/api/cometbft/types/v1/canonical.pb.go#L233-L242
-    /// If the validator has signed, verify: (a)
-    /// - marked as enabled (b)
-    /// - message includes the header hash (c)
-    /// - MsgType is a Precommit message (d)
-    /// - height of the target_header matches the height in the message (e)
-    /// - if round is non-zero, specified round matches message (all validators have same round) (f)
-    /// Verify a == a * b * c * d * e * f
+    /// Verify each validator's signature contains the correct data.
     fn verify_validator_signature_data(
         &mut self,
         header: &TendermintHashVariable,
@@ -93,6 +85,16 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintValidator<L, D> for Circui
         signed: &BoolVariable,
         round: &U64Variable,
     ) {
+        // The protobuf encoding of the signed message of the validator follows the spec here:
+        // https://github.com/cometbft/cometbft/blob/1f430f51f0e390cd7c789ba9b1e9b35846e34642/api/cometbft/types/v1/canonical.pb.go#L233-L242
+        // If the validator has signed, verify: (a)
+        // - marked as enabled (b)
+        // - message includes the header hash (c)
+        // - MsgType is a Precommit message (d)
+        // - height of the target_header matches the height in the message (e)
+        // - if round is non-zero, specified round matches message (all validators have same round) (f)
+        // Verify a == a * b * c * d * e * f
+
         // Verify every signed validator's message includes the header hash.
         let hash_in_message = self.verify_hash_in_message(message, *header, *round);
 

--- a/circuits/skip.rs
+++ b/circuits/skip.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use plonky2x::backend::circuit::Circuit;
 use plonky2x::frontend::hint::asynchronous::hint::AsyncHint;
 use plonky2x::frontend::uint::uint64::U64Variable;
-use plonky2x::frontend::vars::{ValueStream, Variable, VariableStream};
-use plonky2x::prelude::{ArrayVariable, Bytes32Variable, CircuitBuilder, Field, PlonkParameters};
+use plonky2x::frontend::vars::{ValueStream, VariableStream};
+use plonky2x::prelude::{Bytes32Variable, CircuitBuilder, Field, PlonkParameters};
 use serde::{Deserialize, Serialize};
 
 use crate::builder::verify::TendermintVerify;
@@ -42,38 +42,14 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintSkipCircuit<L, D> for Circ
             input_stream,
             SkipOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let target_block_validators =
-            output_stream.read::<ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>>(self);
-        let nb_validators = output_stream.read::<Variable>(self);
-        let target_header = output_stream.read::<Bytes32Variable>(self);
-        let round = output_stream.read::<U64Variable>(self);
-        let target_header_chain_id_proof = output_stream.read::<ChainIdProofVariable>(self);
-        let target_header_block_height_proof = output_stream.read::<HeightProofVariable>(self);
-        let target_header_validators_hash_proof =
-            output_stream.read::<HashInclusionProofVariable>(self);
-        let trusted_header = output_stream.read::<Bytes32Variable>(self);
-        let trusted_header_validators_hash_proof =
-            output_stream.read::<HashInclusionProofVariable>(self);
-        let trusted_header_validators_hash_fields = output_stream
-            .read::<ArrayVariable<ValidatorHashFieldVariable, MAX_VALIDATOR_SET_SIZE>>(self);
-        let trusted_nb_validators = output_stream.read::<Variable>(self);
+        let skip_variable = output_stream.read::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(self);
+
+        let target_header = skip_variable.target_header;
 
         self.verify_skip::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
             skip_max,
-            &trusted_block,
-            &target_block,
-            &target_block_validators,
-            nb_validators,
-            &target_header,
-            &target_header_chain_id_proof,
-            &target_header_block_height_proof,
-            &target_header_validators_hash_proof,
-            &round,
-            trusted_header,
-            &trusted_header_validators_hash_proof,
-            &trusted_header_validators_hash_fields,
-            trusted_nb_validators,
+            &skip_variable,
         );
         target_header
     }
@@ -103,26 +79,25 @@ impl<const MAX_VALIDATOR_SET_SIZE: usize, L: PlonkParameters<D>, const D: usize>
             )
             .await;
 
-        output_stream.write_value::<ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>>(
-            result.target_block_validators,
-        );
-        output_stream
-            .write_value::<Variable>(L::Field::from_canonical_usize(result.nb_target_validators));
-        output_stream.write_value::<Bytes32Variable>(result.target_header.into());
-        output_stream.write_value::<U64Variable>(result.round as u64);
-        output_stream.write_value::<ChainIdProofVariable>(result.target_block_chain_id_proof);
-        output_stream.write_value::<HeightProofVariable>(result.target_block_height_proof);
-        output_stream
-            .write_value::<HashInclusionProofVariable>(result.target_block_validators_hash_proof);
-        output_stream.write_value::<Bytes32Variable>(result.trusted_header.into());
-        output_stream
-            .write_value::<HashInclusionProofVariable>(result.trusted_block_validators_hash_proof);
-        output_stream
-            .write_value::<ArrayVariable<ValidatorHashFieldVariable, MAX_VALIDATOR_SET_SIZE>>(
-                result.trusted_block_validators_hash_fields,
-            );
-        output_stream
-            .write_value::<Variable>(L::Field::from_canonical_usize(result.nb_trusted_validators));
+        let verify_skip_struct = VerifySkipStruct::<MAX_VALIDATOR_SET_SIZE, L::Field> {
+            target_header: result.target_header.into(),
+            target_block,
+            target_block_validators: result.target_block_validators,
+            target_block_nb_validators: L::Field::from_canonical_usize(result.nb_target_validators),
+            target_block_round: result.round as u64,
+            target_header_chain_id_proof: result.target_block_chain_id_proof,
+            target_header_height_proof: result.target_block_height_proof,
+            target_header_validator_hash_proof: result.target_block_validators_hash_proof,
+            trusted_header: result.trusted_header.into(),
+            trusted_block,
+            trusted_block_nb_validators: L::Field::from_canonical_usize(
+                result.nb_trusted_validators,
+            ),
+            trusted_header_validator_hash_proof: result.trusted_block_validators_hash_proof,
+            trusted_header_validator_hash_fields: result.trusted_block_validators_hash_fields,
+        };
+
+        output_stream.write_value::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(verify_skip_struct);
     }
 }
 

--- a/circuits/step.rs
+++ b/circuits/step.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use plonky2x::backend::circuit::Circuit;
 use plonky2x::frontend::hint::asynchronous::hint::AsyncHint;
 use plonky2x::frontend::uint::uint64::U64Variable;
-use plonky2x::frontend::vars::{ValueStream, Variable, VariableStream};
-use plonky2x::prelude::{ArrayVariable, Bytes32Variable, CircuitBuilder, Field, PlonkParameters};
+use plonky2x::frontend::vars::{ValueStream, VariableStream};
+use plonky2x::prelude::{Bytes32Variable, CircuitBuilder, Field, PlonkParameters};
 use serde::{Deserialize, Serialize};
 
 use crate::builder::verify::TendermintVerify;
@@ -36,36 +36,13 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintStepCircuit<L, D> for Circ
             input_stream,
             StepOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let next_header = output_stream.read::<Bytes32Variable>(self);
-        let round = output_stream.read::<U64Variable>(self);
-        let next_block_validators =
-            output_stream.read::<ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>>(self);
-        let nb_validators = output_stream.read::<Variable>(self);
-        let next_block_chain_id_proof = output_stream.read::<ChainIdProofVariable>(self);
-        let next_header_block_height_proof = output_stream.read::<HeightProofVariable>(self);
-        let next_block_validators_hash_proof =
-            output_stream.read::<HashInclusionProofVariable>(self);
-        let next_block_last_block_id_proof =
-            output_stream.read::<BlockIDInclusionProofVariable>(self);
-        let prev_block_next_validators_hash_proof =
-            output_stream.read::<HashInclusionProofVariable>(self);
+        let step_variable = output_stream.read::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(self);
 
-        let one = self.one();
-        let next_block = self.add(prev_block_number, one);
+        let next_header = step_variable.next_header;
 
         self.verify_step::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
-            &next_block_validators,
-            nb_validators,
-            &next_header,
-            &next_block,
-            &next_block_chain_id_proof,
-            &next_header_block_height_proof,
-            &next_block_validators_hash_proof,
-            &next_block_last_block_id_proof,
-            &round,
-            &prev_header_hash,
-            &prev_block_next_validators_hash_proof,
+            &step_variable,
         );
         next_header
     }
@@ -93,21 +70,21 @@ impl<const MAX_VALIDATOR_SET_SIZE: usize, L: PlonkParameters<D>, const D: usize>
             )
             .await;
 
-        output_stream.write_value::<Bytes32Variable>(result.next_header.into());
-        output_stream.write_value::<U64Variable>(result.round as u64); // round
-        output_stream.write_value::<ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>>(
-            result.next_block_validators,
-        );
-        output_stream.write_value::<Variable>(L::Field::from_canonical_usize(result.nb_validators));
-        output_stream.write_value::<ChainIdProofVariable>(result.next_block_chain_id_proof);
-        output_stream.write_value::<HeightProofVariable>(result.next_block_height_proof);
-        output_stream
-            .write_value::<HashInclusionProofVariable>(result.next_block_validators_hash_proof);
-        output_stream
-            .write_value::<BlockIDInclusionProofVariable>(result.next_block_last_block_id_proof);
-        output_stream.write_value::<HashInclusionProofVariable>(
-            result.prev_block_next_validators_hash_proof,
-        );
+        let verify_step_struct = VerifyStepStruct::<MAX_VALIDATOR_SET_SIZE, L::Field> {
+            next_header: result.next_header.into(),
+            next_block: prev_block_number + 1,
+            next_block_validators: result.next_block_validators,
+            next_block_nb_validators: L::Field::from_canonical_usize(result.nb_validators),
+            next_block_round: result.round as u64,
+            next_header_chain_id_proof: result.next_block_chain_id_proof,
+            next_header_height_proof: result.next_block_height_proof,
+            next_header_validators_hash_proof: result.next_block_validators_hash_proof,
+            next_header_last_block_id_proof: result.next_block_last_block_id_proof,
+            prev_header: prev_header_hash,
+            prev_header_next_validators_hash_proof: result.prev_block_next_validators_hash_proof,
+        };
+
+        output_stream.write_value::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(verify_step_struct);
     }
 }
 

--- a/circuits/variables.rs
+++ b/circuits/variables.rs
@@ -91,3 +91,40 @@ pub struct ValidatorHashFieldVariable {
     pub voting_power: U64Variable,
     pub validator_byte_length: Variable,
 }
+
+/// Inputs to verify_skip circuit.
+#[derive(Debug, Clone, CircuitVariable)]
+#[value_name(VerifySkipStruct)]
+pub struct VerifySkipVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
+    pub target_header: TendermintHashVariable,
+    pub target_block: U64Variable,
+    pub target_block_validators: ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>,
+    pub target_block_nb_validators: Variable,
+    pub target_block_round: U64Variable,
+    pub target_header_chain_id_proof: ChainIdProofVariable,
+    pub target_header_height_proof: HeightProofVariable,
+    pub target_header_validator_hash_proof: HashInclusionProofVariable,
+    pub trusted_header: TendermintHashVariable,
+    pub trusted_block: U64Variable,
+    pub trusted_block_nb_validators: Variable,
+    pub trusted_header_validator_hash_proof: HashInclusionProofVariable,
+    pub trusted_header_validator_hash_fields:
+        ArrayVariable<ValidatorHashFieldVariable, MAX_VALIDATOR_SET_SIZE>,
+}
+
+/// Inputs to verify_step circuit.
+#[derive(Debug, Clone, CircuitVariable)]
+#[value_name(VerifyStepStruct)]
+pub struct VerifyStepVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
+    pub next_header: Bytes32Variable,
+    pub next_block: U64Variable,
+    pub next_block_validators: ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>,
+    pub next_block_nb_validators: Variable,
+    pub next_block_round: U64Variable,
+    pub next_header_chain_id_proof: ChainIdProofVariable,
+    pub next_header_height_proof: HeightProofVariable,
+    pub next_header_validators_hash_proof: HashInclusionProofVariable,
+    pub next_header_last_block_id_proof: BlockIDInclusionProofVariable,
+    pub prev_header: Bytes32Variable,
+    pub prev_header_next_validators_hash_proof: HashInclusionProofVariable,
+}


### PR DESCRIPTION
Refactor the inputs to `verify_step` and `verify_skip` to be one large `CircuitVariable` that reads from the hints.

Also, refactor `verify_block_height` to verify the expected height and take in a `HeightProofVariable`.

Based on `ratan/audit_fixes`.