### PR TITLE
fix(audit): constrain step, skip entrypoints

### DIFF
--- a/circuits/skip.rs
+++ b/circuits/skip.rs
@@ -42,7 +42,11 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintSkipCircuit<L, D> for Circ
             input_stream,
             SkipOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let skip_variable = output_stream.read::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(self);
+        let mut skip_variable =
+            output_stream.read::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(self);
+        skip_variable.trusted_block = trusted_block;
+        skip_variable.trusted_header = trusted_header_hash;
+        skip_variable.target_block = target_block;
 
         let target_header = skip_variable.target_header;
 

--- a/circuits/skip.rs
+++ b/circuits/skip.rs
@@ -42,17 +42,16 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintSkipCircuit<L, D> for Circ
             input_stream,
             SkipOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let mut skip_variable =
-            output_stream.read::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(self);
-        skip_variable.trusted_block = trusted_block;
-        skip_variable.trusted_header = trusted_header_hash;
-        skip_variable.target_block = target_block;
+        let skip_variable = output_stream.read::<VerifySkipVariable<MAX_VALIDATOR_SET_SIZE>>(self);
 
         let target_header = skip_variable.target_header;
 
         self.verify_skip::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
             skip_max,
+            trusted_block,
+            trusted_header_hash,
+            target_block,
             &skip_variable,
         );
         target_header
@@ -85,15 +84,12 @@ impl<const MAX_VALIDATOR_SET_SIZE: usize, L: PlonkParameters<D>, const D: usize>
 
         let verify_skip_struct = VerifySkipStruct::<MAX_VALIDATOR_SET_SIZE, L::Field> {
             target_header: result.target_header.into(),
-            target_block,
             target_block_validators: result.target_block_validators,
             target_block_nb_validators: L::Field::from_canonical_usize(result.nb_target_validators),
             target_block_round: result.round as u64,
             target_header_chain_id_proof: result.target_block_chain_id_proof,
             target_header_height_proof: result.target_block_height_proof,
             target_header_validator_hash_proof: result.target_block_validators_hash_proof,
-            trusted_header: result.trusted_header.into(),
-            trusted_block,
             trusted_block_nb_validators: L::Field::from_canonical_usize(
                 result.nb_trusted_validators,
             ),

--- a/circuits/step.rs
+++ b/circuits/step.rs
@@ -36,7 +36,12 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintStepCircuit<L, D> for Circ
             input_stream,
             StepOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let step_variable = output_stream.read::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(self);
+        let mut step_variable =
+            output_stream.read::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(self);
+        step_variable.prev_header = prev_header_hash;
+        let one = self.one();
+        let next_block = self.add(prev_block_number, one);
+        step_variable.next_block = next_block;
 
         let next_header = step_variable.next_header;
 

--- a/circuits/step.rs
+++ b/circuits/step.rs
@@ -36,17 +36,14 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintStepCircuit<L, D> for Circ
             input_stream,
             StepOffchainInputs::<MAX_VALIDATOR_SET_SIZE> {},
         );
-        let mut step_variable =
-            output_stream.read::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(self);
-        step_variable.prev_header = prev_header_hash;
-        let one = self.one();
-        let next_block = self.add(prev_block_number, one);
-        step_variable.next_block = next_block;
+        let step_variable = output_stream.read::<VerifyStepVariable<MAX_VALIDATOR_SET_SIZE>>(self);
 
         let next_header = step_variable.next_header;
 
         self.verify_step::<MAX_VALIDATOR_SET_SIZE, CHAIN_ID_SIZE_BYTES>(
             chain_id_bytes,
+            prev_block_number,
+            prev_header_hash,
             &step_variable,
         );
         next_header
@@ -77,7 +74,6 @@ impl<const MAX_VALIDATOR_SET_SIZE: usize, L: PlonkParameters<D>, const D: usize>
 
         let verify_step_struct = VerifyStepStruct::<MAX_VALIDATOR_SET_SIZE, L::Field> {
             next_header: result.next_header.into(),
-            next_block: prev_block_number + 1,
             next_block_validators: result.next_block_validators,
             next_block_nb_validators: L::Field::from_canonical_usize(result.nb_validators),
             next_block_round: result.round as u64,
@@ -85,7 +81,6 @@ impl<const MAX_VALIDATOR_SET_SIZE: usize, L: PlonkParameters<D>, const D: usize>
             next_header_height_proof: result.next_block_height_proof,
             next_header_validators_hash_proof: result.next_block_validators_hash_proof,
             next_header_last_block_id_proof: result.next_block_last_block_id_proof,
-            prev_header: prev_header_hash,
             prev_header_next_validators_hash_proof: result.prev_block_next_validators_hash_proof,
         };
 

--- a/circuits/variables.rs
+++ b/circuits/variables.rs
@@ -96,16 +96,13 @@ pub struct ValidatorHashFieldVariable {
 #[derive(Debug, Clone, CircuitVariable)]
 #[value_name(VerifySkipStruct)]
 pub struct VerifySkipVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
-    pub target_header: TendermintHashVariable,
-    pub target_block: U64Variable,
+    pub target_header: Bytes32Variable,
     pub target_block_validators: ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>,
     pub target_block_nb_validators: Variable,
     pub target_block_round: U64Variable,
     pub target_header_chain_id_proof: ChainIdProofVariable,
     pub target_header_height_proof: HeightProofVariable,
     pub target_header_validator_hash_proof: HashInclusionProofVariable,
-    pub trusted_header: TendermintHashVariable,
-    pub trusted_block: U64Variable,
     pub trusted_block_nb_validators: Variable,
     pub trusted_header_validator_hash_proof: HashInclusionProofVariable,
     pub trusted_header_validator_hash_fields:
@@ -117,7 +114,6 @@ pub struct VerifySkipVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
 #[value_name(VerifyStepStruct)]
 pub struct VerifyStepVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
     pub next_header: Bytes32Variable,
-    pub next_block: U64Variable,
     pub next_block_validators: ArrayVariable<ValidatorVariable, MAX_VALIDATOR_SET_SIZE>,
     pub next_block_nb_validators: Variable,
     pub next_block_round: U64Variable,
@@ -125,6 +121,5 @@ pub struct VerifyStepVariable<const MAX_VALIDATOR_SET_SIZE: usize> {
     pub next_header_height_proof: HeightProofVariable,
     pub next_header_validators_hash_proof: HashInclusionProofVariable,
     pub next_header_last_block_id_proof: BlockIDInclusionProofVariable,
-    pub prev_header: Bytes32Variable,
     pub prev_header_next_validators_hash_proof: HashInclusionProofVariable,
 }


### PR DESCRIPTION
Previously, the hint overrode the "trusted" public inputs with `skip_variable` and `step_variable`, making them potentially untrusted & manipulable. To ensure the security of the circuit, explicitly pass the public inputs into `verify_step` and `verify_skip`.