### PR TITLE
chore: `must_use`

### DIFF
--- a/circuits/builder/shared.rs
+++ b/circuits/builder/shared.rs
@@ -36,6 +36,7 @@ pub trait TendermintHeader<L: PlonkParameters<D>, const D: usize> {
     );
 
     /// Get result of AND operation for BoolVariable array.
+    #[must_use]
     fn combine_with_and(&mut self, arr: &[BoolVariable]) -> BoolVariable;
 }
 

--- a/circuits/builder/validator.rs
+++ b/circuits/builder/validator.rs
@@ -32,6 +32,7 @@ pub trait TendermintValidator<L: PlonkParameters<D>, const D: usize> {
 
     /// Extract the header hash from the signed message from a validator. The location of the
     /// header hash in the signed message depends on whether the round is 0 for the message.
+    #[must_use]
     fn verify_hash_in_message(
         &mut self,
         message: &ValidatorMessageVariable,

--- a/circuits/builder/voting.rs
+++ b/circuits/builder/voting.rs
@@ -15,6 +15,7 @@ pub trait TendermintVoting {
     ) -> U64Variable;
 
     /// Assert the enabled voting power > threshold * total voting power.
+    #[must_use]
     fn is_voting_power_greater_than_threshold<const VALIDATOR_SET_SIZE_MAX: usize>(
         &mut self,
         validator_voting_power: &[U64Variable],


### PR DESCRIPTION
Add `must_use` to all functions that return `BoolVariable`.