### PR TITLE
fix(audit): skip verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ There are two entrypoints to a `TendermintX` contract, `step` and `skip`.
 
 `skip` is used to jump from the current header to a non-consecutive header.
 
-For example, let's say block N has already been proven in the light client, and we want to prove block N+10. If validators from block N represent more than 1/3 of the voting power in block N+10, then we can skip from block N to block N+10, as long as 1) the validators from the trusted block have signed the new block, and 2) the new block is valid.
+For example, let's say block N has already been proven in the light client, and we want to prove block N+10. We can skip from block N to block N+10 if 1) the validators who have signed the commit for block N+10 comprise > 1/3 of the voting power on block N and 2) validators comprimising > 2/3 of the voting power on block N+10 have signed the commit for block N+10.
 
-The methodology for doing so is described in the section 2.3 of [A Tendermint Light Client](https://arxiv.org/pdf/2010.07031.pdf).
+The methodology for doing so is described in the section 6 of [A Tendermint Light Client](https://arxiv.org/pdf/2010.07031.pdf).
 
 ### step
 

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -578,7 +578,7 @@ pub(crate) mod tests {
         // This is a test case generated from block 144094 of Celestia's Mocha 3 testnet
         // Block Hash: 8909e1b73b7d987e95a7541d96ed484c17a4b0411e98ee4b7c890ad21302ff8c (needs to be lower case)
         // Signed Message (from the last validator): 6b080211de3202000000000022480a208909e1b73b7d987e95a7541d96ed484c17a4b0411e98ee4b7c890ad21302ff8c12240801122061263df4855e55fcab7aab0a53ee32cf4f29a1101b56de4a9d249d44e4cf96282a0b089dce84a60610ebb7a81932076d6f6368612d33
-        // No round exists in present the message that was signed above
+        // No round exists in the message that was signed above.
 
         env_logger::try_init().unwrap_or_default();
 

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -401,15 +401,16 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
             // For each target validator i that has signed, if a trusted validator j has the same pubkey,
             // set the flag of trusted validator j to true.
             for j in 0..VALIDATOR_SET_SIZE_MAX {
-                let pubkey_match_idx = self.is_equal(
+                let pubkeys_match = self.is_equal(
                     validators[i].pubkey.clone(),
                     trusted_validator_hash_fields[j].pubkey.clone(),
                 );
 
-                let signed_and_pubkey_match = self.and(pubkey_match_idx, signed_target_header);
+                let signed_target_header_and_pubkey_match =
+                    self.and(pubkeys_match, signed_target_header);
 
                 trusted_validator_signed_on_target_header[j] = self.select(
-                    signed_and_pubkey_match,
+                    signed_target_header_and_pubkey_match,
                     true_var,
                     trusted_validator_signed_on_target_header[j],
                 );

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -398,8 +398,8 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         for i in 0..VALIDATOR_SET_SIZE_MAX {
             let signed_target_header = validators[i].signed;
 
-            // For each target validator that has signed, if a trusted validator has the same pubkey,
-            // set the flag of the trusted validator to true.
+            // For each target validator i that has signed, if a trusted validator j has the same pubkey,
+            // set the flag of trusted validator j to true.
             for j in 0..VALIDATOR_SET_SIZE_MAX {
                 let pubkey_match_idx = self.is_equal(
                     validators[i].pubkey.clone(),

--- a/circuits/builder/verify.rs
+++ b/circuits/builder/verify.rs
@@ -66,8 +66,8 @@ pub trait TendermintVerify<L: PlonkParameters<D>, const D: usize> {
         nb_enabled_validators: Variable,
     ) -> TendermintHashVariable;
 
-    /// Verify the set of validators from the target block comprise more than 1/3 of the voting
-    /// power on the trusted block.
+    /// Verify the set of validators who've signed on the commit from the target block comprise more
+    /// than 1/3 of the voting power on the trusted block.
     fn verify_trusted_validators<const VALIDATOR_SET_SIZE_MAX: usize>(
         &mut self,
         validators: &ArrayVariable<ValidatorVariable, VALIDATOR_SET_SIZE_MAX>,
@@ -534,8 +534,8 @@ impl<L: PlonkParameters<D>, const D: usize> TendermintVerify<L, D> for CircuitBu
         // skip distance.
         self.verify_skip_distance(skip_max, &trusted_block, &target_block);
 
-        // Verify the set of validators from the target block comprise more than 1/3 of the voting
-        // power on the trusted block.
+        // Verify the set of validators who've signed on the commit from the target block comprise
+        // more than 1/3 of the voting power on the trusted block.
         self.verify_trusted_validators(
             &skip.target_block_validators,
             trusted_header_hash,

--- a/circuits/input/mod.rs
+++ b/circuits/input/mod.rs
@@ -15,7 +15,6 @@ use tendermint::validator::{Info, Set as TendermintValidatorSet};
 use tendermint_proto::types::BlockId as RawBlockId;
 use tendermint_proto::Protobuf;
 
-use self::conversion::update_present_on_trusted_header;
 use self::tendermint_utils::{
     generate_proofs_from_header, is_valid_skip, CommitResponse, Hash, Header, Proof,
     ValidatorSetResponse,
@@ -460,15 +459,9 @@ impl InputDataFetcher {
         let target_block_header = target_signed_header.header.hash();
         let round = target_signed_header.commit.round.value() as usize;
 
-        let mut target_block_validators = get_validator_data_from_block::<VALIDATOR_SET_SIZE_MAX, F>(
+        let target_block_validators = get_validator_data_from_block::<VALIDATOR_SET_SIZE_MAX, F>(
             &target_block_validator_set,
             &target_signed_header,
-        );
-        update_present_on_trusted_header(
-            &mut target_block_validators,
-            &target_signed_header.commit,
-            &target_block_validator_set,
-            &trusted_block_validator_set,
         );
 
         let encoded_chain_id = target_signed_header.header.chain_id.clone().encode_vec();

--- a/circuits/variables.rs
+++ b/circuits/variables.rs
@@ -65,8 +65,7 @@ pub type BlockIDInclusionProofVariable =
 /// power, validator byte length, and three flags: enabled, and signed..
 ///
 /// A validator is marked as enabled if it is a part of the validator set for the specified block.
-/// A validator is marked as signed if it has signed the block. A validator is marked as present on
-/// trusted header if it is a part of the validator set for the trusted header (only used in skip).
+/// A validator is marked as signed if it has signed the block.
 #[derive(Debug, Clone, CircuitVariable)]
 #[value_name(ValidatorType)]
 pub struct ValidatorVariable {

--- a/circuits/variables.rs
+++ b/circuits/variables.rs
@@ -81,9 +81,7 @@ pub struct ValidatorVariable {
     pub present_on_trusted_header: BoolVariable,
 }
 
-/// A validator hash field is a struct containing the pubkey, voting power, validator byte length,
-/// and enabled flag of a validator. A validator is marked as enabled if it is a part of the
-/// validator set for the specified block height.
+/// A validator hash field is a struct containing the pubkey, voting power & validator byte length.
 #[derive(Debug, Clone, CircuitVariable)]
 #[value_name(ValidatorHashField)]
 pub struct ValidatorHashFieldVariable {

--- a/circuits/variables.rs
+++ b/circuits/variables.rs
@@ -62,7 +62,7 @@ pub type BlockIDInclusionProofVariable =
     MerkleInclusionProofVariable<HEADER_PROOF_DEPTH, PROTOBUF_BLOCK_ID_SIZE_BYTES>;
 
 /// A validator is a struct containing the pubkey, signature, message, message byte length, voting
-/// power, validator byte length, and three flags: enabled, signed, and present_on_trusted_header.
+/// power, validator byte length, and three flags: enabled, and signed..
 ///
 /// A validator is marked as enabled if it is a part of the validator set for the specified block.
 /// A validator is marked as signed if it has signed the block. A validator is marked as present on
@@ -77,8 +77,6 @@ pub struct ValidatorVariable {
     pub voting_power: U64Variable,
     pub validator_byte_length: Variable,
     pub signed: BoolVariable,
-    // Only used in skip circuit.
-    pub present_on_trusted_header: BoolVariable,
 }
 
 /// A validator hash field is a struct containing the pubkey, voting power & validator byte length.


### PR DESCRIPTION
## Overview
- Verify validators who've signed the commit on the target block comprise 1/3 of the voting power on the trusted block.
- Clean up documentation to remove `present_on_trusted_header`, which is no longer necessary.

## Spec
The spec for the security of `skip` can be found in Section 6 of https://arxiv.org/pdf/2010.07031.pdf

![image](https://github.com/succinctlabs/tendermintx/assets/34041956/52bc8089-0580-4924-82ef-c3d0da55d778)
