### PR TITLE
feat: add genesis script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ name = "skip"
 path = "bin/skip.rs"
 
 [[bin]]
+name = "genesis"
+path = "bin/genesis.rs"
+
+[[bin]]
 name = "tendermintx"
 path = "bin/tendermintx.rs"
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ There are currently Tendermint X light clients tracking the following networks o
 
 10. Open the code for your fork of `TendermintX` again.
 
-11. Update `contracts/.env` accoridng to `contracts/.env.example`. Note: The genesis parameters are typically sourced from a recent header from your Tendermint chain.
+11. Fetch the trusted initialization parameters of the Tendermint X light client from a chain RPC. Add `TENDERMINT_RPC_URL` for your chain to your `.env` and then run `cargo run --bin genesis -- --block N`, where N is the initialization height of the light client. `N` and the corresponding hash of block `N` will be used as `GENESIS_HEIGHT` and `GENESIS_HEADER` in `contracts/.env` in the next step.
 
-12. Deploy your `TendermintX` contract and initialize it with your function ID & genesis parameters using the commands below.
+12. Update `contracts/.env` accoridng to `contracts/.env.example`. Note: The genesis parameters are typically sourced from a recent header from your Tendermint chain.
+
+13. Deploy your `TendermintX` contract and initialize it with your function ID & genesis parameters using the commands below.
 
 ```
 forge install

--- a/bin/genesis.rs
+++ b/bin/genesis.rs
@@ -1,0 +1,33 @@
+use std::env;
+
+use clap::Parser;
+use log::info;
+use tendermintx::input::InputDataFetcher;
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Get the genesis parameters from a block.")]
+pub struct GenesisArgs {
+    #[arg(long, default_value = "1")]
+    pub block: u64,
+}
+
+#[tokio::main]
+pub async fn main() {
+    env::set_var("RUST_LOG", "info");
+    dotenv::dotenv().ok();
+    env_logger::init();
+    let data_fetcher = InputDataFetcher::default();
+    let args = GenesisArgs::parse();
+
+    let genesis_block = args.block;
+
+    let signed_header = data_fetcher
+        .get_signed_header_from_number(genesis_block)
+        .await;
+    let header_hash = signed_header.header.hash();
+    info!(
+        "Block {}'s header hash: {:?}",
+        genesis_block,
+        header_hash.to_string()
+    );
+}


### PR DESCRIPTION
**Overview**
Add a script for fetching the genesis initialization parameters of the contract & update docs to include instructions for the script.

**Misc**
- `GENESIS_HEADER` is potentially confusing with the genesis of a chain, and should be renamed to `INIT_HEADER` or in a future version.
- The instructions for deploying `TendermintX` are confusing after the addition of chain configurations, as you need to edit `config.rs` and `consts.rs`.